### PR TITLE
New file cleanup features, support for artist lidarr processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,11 @@ Edit the "config.sample" file, fill your paramaters and save as "config".<br>
 * LidarrUrl - 				Set domain or IP to your Lidarr instance including port. If using reverse proxy, do not use a trailing slash.<br>
 * LidarrApikey - 			Lidarr api key.<br>
 * quality - 				SMLoadr Download Quality setting (MP3_128,MP3_320,FLAC).<br>
+* KeepOnly -					Keeps only the requested Download Quality<br>
 * logname -					Log file name.<br>
 * skiplogname -				Logs any info if an item was skipped.<br>
+* CannotImport -				Removes files that cannot be imported by Lidarr automatically (.jpg, .lrc).<br>
+* CleanStart -				Purges files from SMLoadr Download directory at start of script<br>
 * mode -					Mode to choose what to scrape from Lidarr, wanted gets only the albums that are marked wanted, artist gets all the albums from the monitored artists.<br>
 * EnableLidarrProcess -		Set to True to instruct Lidarr to process the download once smloadr finishes.<br>
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Edit the "config.sample" file, fill your paramaters and save as "config".<br>
 * CannotImport -				Removes files that cannot be imported by Lidarr automatically (.jpg, .lrc).<br>
 * CleanStart -				Purges files from SMLoadr Download directory at start of script<br>
 * mode -					Mode to choose what to scrape from Lidarr, wanted gets only the albums that are marked wanted, artist gets all the albums from the monitored artists.<br>
+* ExternalProcess -				Enables the downloaded files to be moved and picked up by other applications/scripts that you have setup. This replaces the EnableLidarrProccess import process.<br>
+* externalprocessdirectory -				Directory that you want to move downloaded files to for processing with other scripts or applications such as Beets.<br>
 * EnableLidarrProcess -		Set to True to instruct Lidarr to process the download once smloadr finishes.<br>
 
 Below are only used if "mode" is set to "wanted".<br>

--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ Edit the "config.sample" file, fill your paramaters and save as "config".<br>
 * logname -					Log file name.<br>
 * skiplogname -				Logs any info if an item was skipped.<br>
 * mode -					Mode to choose what to scrape from Lidarr, wanted gets only the albums that are marked wanted, artist gets all the albums from the monitored artists.<br>
+* EnableLidarrProcess -		Set to True to instruct Lidarr to process the download once smloadr finishes.<br>
 
 Below are only used if "mode" is set to "wanted".<br>
 * wantedalbumsamount -		The amount of wanted albums to process it will grab the newest x amount of albums from the Lidarr wanted list.<br>
-* EnableLidarrProcess -		Set to True to instruct Lidarr to process the download once smloadr finishes.<br>
 * EnableFuzzyAlbumSearch -	Set to True to enable fuzzy album search if theres no exact match.<br>
 
 # Requirements

--- a/config.sample
+++ b/config.sample
@@ -20,6 +20,10 @@ skiplogname=skipped.csv
 CannotImport=False
 #When set to True, smloadr downloads directory contents is purged on initialization
 CleanStart=False
+#When set to True, you will enable the downloaded files to be moved and picked up by other applications/scripts that you have setup. This replaces scripts Lidarr import process.
+ExternalProcess=False
+#Directory that you want to move downloaded files to for processing with other scripts or applications such as Beets
+externalprocessdirectory=/opt/beets/import
 #mode to choose what to passthrough to smloadr, "wanted" gets only the albums that are marked as monitored in lidarr, "artist" will just passthrough the artist. (wanted,artist) 
 mode=wanted
 #set to True to instruct Lidarr to process the download once smloadr finishes

--- a/config.sample
+++ b/config.sample
@@ -10,10 +10,16 @@ lidarrUrl="http://192.168.1.x:8686"
 lidarrApiKey="08d108d108d108d108d108d108d108d1"
 #SMLoadr Download Quality setting (MP3_128,MP3_320,FLAC)
 quality="MP3_320"
+#Keeps only quality type selected above
+KeepOnly=False
 #logfilename
 logname=smloadr-script.log
 #logs any info if an item was skipped
 skiplogname=skipped.csv
+#set to True to delete files and empty folders that cannot be imported by Lidarr ".lrc" & ".jpg" files
+CannotImport=False
+#When set to True, smloadr downloads directory contents is purged on initialization
+CleanStart=False
 #mode to choose what to passthrough to smloadr, "wanted" gets only the albums that are marked as monitored in lidarr, "artist" will just passthrough the artist. (wanted,artist) 
 mode=wanted
 #set to True to instruct Lidarr to process the download once smloadr finishes

--- a/config.sample
+++ b/config.sample
@@ -16,6 +16,8 @@ logname=smloadr-script.log
 skiplogname=skipped.csv
 #mode to choose what to passthrough to smloadr, "wanted" gets only the albums that are marked as monitored in lidarr, "artist" will just passthrough the artist. (wanted,artist) 
 mode=wanted
+#set to True to instruct Lidarr to process the download once smloadr finishes
+EnableLidarrProcess=True
 
 #The below config is only used if mode = wanted
 #The amount of wanted albums to process it will grab the newest x amount of albums from the lidarr wanted list

--- a/config.sample
+++ b/config.sample
@@ -20,12 +20,12 @@ skiplogname=skipped.csv
 CannotImport=False
 #When set to True, smloadr downloads directory contents is purged on initialization
 CleanStart=False
+#mode to choose what to passthrough to smloadr, "wanted" gets only the albums that are marked as monitored in lidarr, "artist" will just passthrough the artist. (wanted,artist) 
+mode=wanted
 #When set to True, you will enable the downloaded files to be moved and picked up by other applications/scripts that you have setup. This replaces scripts Lidarr import process.
 ExternalProcess=False
 #Directory that you want to move downloaded files to for processing with other scripts or applications such as Beets
 externalprocessdirectory=/opt/beets/import
-#mode to choose what to passthrough to smloadr, "wanted" gets only the albums that are marked as monitored in lidarr, "artist" will just passthrough the artist. (wanted,artist) 
-mode=wanted
 #set to True to instruct Lidarr to process the download once smloadr finishes
 EnableLidarrProcess=True
 

--- a/config.sample
+++ b/config.sample
@@ -22,7 +22,5 @@ EnableLidarrProcess=True
 #The below config is only used if mode = wanted
 #The amount of wanted albums to process it will grab the newest x amount of albums from the lidarr wanted list
 wantedalbumsamount=10
-#set to True to instruct Lidarr to process the download once smloadr finishes
-EnableLidarrProcess=True
 #set to True to enable fuzzy album search if theres no exact match
 EnableFuzzyAlbumSearch=True

--- a/lidarr-smloadr.sh
+++ b/lidarr-smloadr.sh
@@ -163,8 +163,10 @@ WantedModeBegin(){
 		fi
 		if [ "${EnableLidarrProcess}" = True ] && [ -n "${LidArtistDLName}" ];then
 				logit "Sending to Lidarr for post Processing"
-				dlloc="${downloadDir}/${LidArtistDLName}/"
-				LidarrProcessIt=$(curl -s "$lidarrUrl/api/v1/command" --header "X-Api-Key:"${lidarrApiKey} --data '{"name":"DownloadedAlbumsScan", "path":"'"$dlloc"'"}' );
+				dlloc="${downloadDir}/*
+				for d in $dlloc; do
+					LidarrProcessIt=$(curl -s "$lidarrUrl/api/v1/command" --header "X-Api-Key:"${lidarrApiKey} --data '{"name":"DownloadedAlbumsScan", "path":"'"$d"'"}' );
+				done
 		else
 			logit "Skipping Lidarr Processing"
 		fi

--- a/lidarr-smloadr.sh
+++ b/lidarr-smloadr.sh
@@ -97,7 +97,36 @@ DownloadURL(){
 	logit "Download Complete"
 }
 
+CleanStart(){
+	if [ "${CannotImport}" = True ];then
+		logit "Removing previously downloaded files form smloadr downloads directory"
+		rm -rf ${downloadDir}/*
+	else
+		logit "Skipping CleanStart"
+	fi
+}
 
+Cleanup(){
+	if [ "${KeepOnly}" = True ];then
+		if [ "${quality}" = FLAC ];then
+			logit "Removing unwanted MP3's"
+			find ${downloadDir}/. -name "*.mp3" -type f -delete
+		else
+			logit "Removing unwanted FLAC's"
+			find ${downloadDir}/. -type f -name "*.flac" -type f -delete
+		fi
+	else
+		logit "Skipping KeepOnly Quality Cleanup"
+	fi
+	if [ "${CannotImport}" = True ];then
+		logit "Removing files that cannot be imported to Lidarr and empty folders"
+		find ${downloadDir}/. -type f -name "*.lrc" -type f -delete
+		find ${downloadDir}/. -type f -name "*.jpg" -type f -delete
+		find ${downloadDir}/ -empty -type d -delete
+	else
+		logit "Skipping Unwanted file removal"
+	fi
+}
 
 ErrorExit(){
 	case ${2} in
@@ -161,6 +190,7 @@ WantedModeBegin(){
 			skiplog "${LidArtistName};${DeezerArtistID};${DeezerArtistURL};${LidAlbumName};${DeezerDiscogArr[*]}"
 			continue
 		fi
+		Cleanup
 		if [ "${EnableLidarrProcess}" = True ] && [ -n "${LidArtistDLName}" ];then
 				logit "Sending to Lidarr for post Processing"
 				dlloc=${downloadDir}/*
@@ -198,30 +228,30 @@ ArtistModeBegin(){
 		echo "-Querying"
 		if [ -n "${DeezerArtistID}" ] || [ -n "${LidArtistName}" ] || [ -n "${DeezerArtistURL}" ]; then
 			DownloadURL "${DeezerArtistURL}"
-			logit "DeezerArtistURL: ${DeezerArtistURL}"
-			
-			if [ "${EnableLidarrProcess}" = True ];then
-				logit "Sending to Lidarr for post Processing"
-				dlloc=${downloadDir}/*
-				for d in $dlloc; do
-					LidarrProcessIt=$(curl -s "$lidarrUrl/api/v1/command" --header "X-Api-Key:"${lidarrApiKey} --data '{"name":"DownloadedAlbumsScan", "path":"'"$d"'"}' );
-				done
-			else
-			logit "Skipping Lidarr Processing"
-			fi
-			
+			logit "DeezerArtistURL: ${DeezerArtistURL}"			
 		else
 			logit "Cant get artistname or or DeezerArtistURL or artistid.. skipping" 
 			skiplog "${LidArtistName};${DeezerArtistID};${DeezerArtistURL};${LidAlbumName}"
 			continue
 		fi
 	done
+	Cleanup
+	if [ "${EnableLidarrProcess}" = True ];then
+		logit "Sending to Lidarr for post Processing"
+		dlloc=${downloadDir}/*
+		for d in $dlloc; do
+			LidarrProcessIt=$(curl -s "$lidarrUrl/api/v1/command" --header "X-Api-Key:"${lidarrApiKey} --data '{"name":"DownloadedAlbumsScan", "path":"'"$d"'"}' );
+		done
+	else
+		logit "Skipping Lidarr Processing"
+	fi
 }
 
 main(){
 	echo "Starting up"
 	source ./config || ErrorExit "Configuration file not found" 2
 	InitLogs
+	CleanStart
 	case "${mode}" in 
 		wanted)	WantedModeBegin;;
 		artist) ArtistModeBegin;;

--- a/lidarr-smloadr.sh
+++ b/lidarr-smloadr.sh
@@ -163,7 +163,7 @@ WantedModeBegin(){
 		fi
 		if [ "${EnableLidarrProcess}" = True ] && [ -n "${LidArtistDLName}" ];then
 				logit "Sending to Lidarr for post Processing"
-				dlloc="${downloadDir}/*
+				dlloc=${downloadDir}/*
 				for d in $dlloc; do
 					LidarrProcessIt=$(curl -s "$lidarrUrl/api/v1/command" --header "X-Api-Key:"${lidarrApiKey} --data '{"name":"DownloadedAlbumsScan", "path":"'"$d"'"}' );
 				done

--- a/lidarr-smloadr.sh
+++ b/lidarr-smloadr.sh
@@ -199,6 +199,17 @@ ArtistModeBegin(){
 		if [ -n "${DeezerArtistID}" ] || [ -n "${LidArtistName}" ] || [ -n "${DeezerArtistURL}" ]; then
 			DownloadURL "${DeezerArtistURL}"
 			logit "DeezerArtistURL: ${DeezerArtistURL}"
+			
+			if [ "${EnableLidarrProcess}" = True ];then
+				logit "Sending to Lidarr for post Processing"
+				dlloc=${downloadDir}/*
+				for d in $dlloc; do
+					LidarrProcessIt=$(curl -s "$lidarrUrl/api/v1/command" --header "X-Api-Key:"${lidarrApiKey} --data '{"name":"DownloadedAlbumsScan", "path":"'"$d"'"}' );
+				done
+			else
+			logit "Skipping Lidarr Processing"
+			fi
+			
 		else
 			logit "Cant get artistname or or DeezerArtistURL or artistid.. skipping" 
 			skiplog "${LidArtistName};${DeezerArtistID};${DeezerArtistURL};${LidAlbumName}"


### PR DESCRIPTION
The current situation is, that some artists will not import properly because they are attempting to use the Lidarr Artist name for the path to the files. This changes it to enable Lidarr to run a scan on all downloaded artist folders and will now import accordingly.

Edit: I have added additional file cleanup enhancements after originally opening this request