### PR TITLE
External processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,11 @@ Edit the "config.sample" file, fill your paramaters and save as "config".<br>
 * LidarrUrl - 				Set domain or IP to your Lidarr instance including port. If using reverse proxy, do not use a trailing slash.<br>
 * LidarrApikey - 			Lidarr api key.<br>
 * quality - 				SMLoadr Download Quality setting (MP3_128,MP3_320,FLAC).<br>
+* KeepOnly -					Keeps only the requested Download Quality<br>
 * logname -					Log file name.<br>
 * skiplogname -				Logs any info if an item was skipped.<br>
+* CannotImport -				Removes files that cannot be imported by Lidarr automatically (.jpg, .lrc).<br>
+* CleanStart -				Purges files from SMLoadr Download directory at start of script<br>
 * mode -					Mode to choose what to scrape from Lidarr, wanted gets only the albums that are marked wanted, artist gets all the albums from the monitored artists.<br>
 * EnableLidarrProcess -		Set to True to instruct Lidarr to process the download once smloadr finishes.<br>
 

--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ Edit the "config.sample" file, fill your paramaters and save as "config".<br>
 * logname -					Log file name.<br>
 * skiplogname -				Logs any info if an item was skipped.<br>
 * mode -					Mode to choose what to scrape from Lidarr, wanted gets only the albums that are marked wanted, artist gets all the albums from the monitored artists.<br>
+* EnableLidarrProcess -		Set to True to instruct Lidarr to process the download once smloadr finishes.<br>
 
 Below are only used if "mode" is set to "wanted".<br>
 * wantedalbumsamount -		The amount of wanted albums to process it will grab the newest x amount of albums from the Lidarr wanted list.<br>
-* EnableLidarrProcess -		Set to True to instruct Lidarr to process the download once smloadr finishes.<br>
 * EnableFuzzyAlbumSearch -	Set to True to enable fuzzy album search if theres no exact match.<br>
 
 # Requirements

--- a/config.sample
+++ b/config.sample
@@ -10,10 +10,16 @@ lidarrUrl="http://192.168.1.x:8686"
 lidarrApiKey="08d108d108d108d108d108d108d108d1"
 #SMLoadr Download Quality setting (MP3_128,MP3_320,FLAC)
 quality="MP3_320"
+#Keeps only quality type selected above
+KeepOnly=False
 #logfilename
 logname=smloadr-script.log
 #logs any info if an item was skipped
 skiplogname=skipped.csv
+#set to True to delete files and empty folders that cannot be imported by Lidarr ".lrc" & ".jpg" files
+CannotImport=False
+#When set to True, smloadr downloads directory contents is purged on initialization
+CleanStart=False
 #mode to choose what to passthrough to smloadr, "wanted" gets only the albums that are marked as monitored in lidarr, "artist" will just passthrough the artist. (wanted,artist) 
 mode=wanted
 #set to True to instruct Lidarr to process the download once smloadr finishes

--- a/config.sample
+++ b/config.sample
@@ -16,6 +16,8 @@ logname=smloadr-script.log
 skiplogname=skipped.csv
 #mode to choose what to passthrough to smloadr, "wanted" gets only the albums that are marked as monitored in lidarr, "artist" will just passthrough the artist. (wanted,artist) 
 mode=wanted
+#set to True to instruct Lidarr to process the download once smloadr finishes
+EnableLidarrProcess=True
 
 #The below config is only used if mode = wanted
 #The amount of wanted albums to process it will grab the newest x amount of albums from the lidarr wanted list

--- a/config.sample
+++ b/config.sample
@@ -22,7 +22,5 @@ EnableLidarrProcess=True
 #The below config is only used if mode = wanted
 #The amount of wanted albums to process it will grab the newest x amount of albums from the lidarr wanted list
 wantedalbumsamount=10
-#set to True to instruct Lidarr to process the download once smloadr finishes
-EnableLidarrProcess=True
 #set to True to enable fuzzy album search if theres no exact match
 EnableFuzzyAlbumSearch=True

--- a/lidarr-smloadr.sh
+++ b/lidarr-smloadr.sh
@@ -163,8 +163,10 @@ WantedModeBegin(){
 		fi
 		if [ "${EnableLidarrProcess}" = True ] && [ -n "${LidArtistDLName}" ];then
 				logit "Sending to Lidarr for post Processing"
-				dlloc="${downloadDir}/${LidArtistDLName}/"
-				LidarrProcessIt=$(curl -s "$lidarrUrl/api/v1/command" --header "X-Api-Key:"${lidarrApiKey} --data '{"name":"DownloadedAlbumsScan", "path":"'"$dlloc"'"}' );
+				dlloc="${downloadDir}/*
+				for d in $dlloc; do
+					LidarrProcessIt=$(curl -s "$lidarrUrl/api/v1/command" --header "X-Api-Key:"${lidarrApiKey} --data '{"name":"DownloadedAlbumsScan", "path":"'"$d"'"}' );
+				done
 		else
 			logit "Skipping Lidarr Processing"
 		fi

--- a/lidarr-smloadr.sh
+++ b/lidarr-smloadr.sh
@@ -97,7 +97,36 @@ DownloadURL(){
 	logit "Download Complete"
 }
 
+CleanStart(){
+	if [ "${CannotImport}" = True ];then
+		logit "Removing previously downloaded files form smloadr downloads directory"
+		rm -rf ${downloadDir}/*
+	else
+		logit "Skipping CleanStart"
+	fi
+}
 
+Cleanup(){
+	if [ "${KeepOnly}" = True ];then
+		if [ "${quality}" = FLAC ];then
+			logit "Removing unwanted MP3's"
+			find ${downloadDir}/. -name "*.mp3" -type f -delete
+		else
+			logit "Removing unwanted FLAC's"
+			find ${downloadDir}/. -type f -name "*.flac" -type f -delete
+		fi
+	else
+		logit "Skipping KeepOnly Quality Cleanup"
+	fi
+	if [ "${CannotImport}" = True ];then
+		logit "Removing files that cannot be imported to Lidarr and empty folders"
+		find ${downloadDir}/. -type f -name "*.lrc" -type f -delete
+		find ${downloadDir}/. -type f -name "*.jpg" -type f -delete
+		find ${downloadDir}/ -empty -type d -delete
+	else
+		logit "Skipping Unwanted file removal"
+	fi
+}
 
 ErrorExit(){
 	case ${2} in
@@ -161,6 +190,7 @@ WantedModeBegin(){
 			skiplog "${LidArtistName};${DeezerArtistID};${DeezerArtistURL};${LidAlbumName};${DeezerDiscogArr[*]}"
 			continue
 		fi
+		Cleanup
 		if [ "${EnableLidarrProcess}" = True ] && [ -n "${LidArtistDLName}" ];then
 				logit "Sending to Lidarr for post Processing"
 				dlloc=${downloadDir}/*
@@ -198,30 +228,30 @@ ArtistModeBegin(){
 		echo "-Querying"
 		if [ -n "${DeezerArtistID}" ] || [ -n "${LidArtistName}" ] || [ -n "${DeezerArtistURL}" ]; then
 			DownloadURL "${DeezerArtistURL}"
-			logit "DeezerArtistURL: ${DeezerArtistURL}"
-			
-			if [ "${EnableLidarrProcess}" = True ];then
-				logit "Sending to Lidarr for post Processing"
-				dlloc=${downloadDir}/*
-				for d in $dlloc; do
-					LidarrProcessIt=$(curl -s "$lidarrUrl/api/v1/command" --header "X-Api-Key:"${lidarrApiKey} --data '{"name":"DownloadedAlbumsScan", "path":"'"$d"'"}' );
-				done
-			else
-			logit "Skipping Lidarr Processing"
-			fi
-			
+			logit "DeezerArtistURL: ${DeezerArtistURL}"			
 		else
 			logit "Cant get artistname or or DeezerArtistURL or artistid.. skipping" 
 			skiplog "${LidArtistName};${DeezerArtistID};${DeezerArtistURL};${LidAlbumName}"
 			continue
 		fi
 	done
+	Cleanup
+	if [ "${EnableLidarrProcess}" = True ];then
+		logit "Sending to Lidarr for post Processing"
+		dlloc=${downloadDir}/*
+		for d in $dlloc; do
+			LidarrProcessIt=$(curl -s "$lidarrUrl/api/v1/command" --header "X-Api-Key:"${lidarrApiKey} --data '{"name":"DownloadedAlbumsScan", "path":"'"$d"'"}' );
+		done
+	else
+		logit "Skipping Lidarr Processing"
+	fi
 }
 
 main(){
 	echo "Starting up"
 	source ./config || ErrorExit "Configuration file not found" 2
 	InitLogs
+	CleanStart
 	case "${mode}" in 
 		wanted)	WantedModeBegin;;
 		artist) ArtistModeBegin;;

--- a/lidarr-smloadr.sh
+++ b/lidarr-smloadr.sh
@@ -163,7 +163,7 @@ WantedModeBegin(){
 		fi
 		if [ "${EnableLidarrProcess}" = True ] && [ -n "${LidArtistDLName}" ];then
 				logit "Sending to Lidarr for post Processing"
-				dlloc="${downloadDir}/*
+				dlloc=${downloadDir}/*
 				for d in $dlloc; do
 					LidarrProcessIt=$(curl -s "$lidarrUrl/api/v1/command" --header "X-Api-Key:"${lidarrApiKey} --data '{"name":"DownloadedAlbumsScan", "path":"'"$d"'"}' );
 				done

--- a/lidarr-smloadr.sh
+++ b/lidarr-smloadr.sh
@@ -110,10 +110,10 @@ Cleanup(){
 	if [ "${KeepOnly}" = True ];then
 		if [ "${quality}" = FLAC ];then
 			logit "Removing unwanted MP3's"
-			find ${downloadDir}/. -name "*.mp3" -type f -delete
+			find ${downloadDir}/. -type f -name "*.mp3" -delete
 		else
 			logit "Removing unwanted FLAC's"
-			find ${downloadDir}/. -type f -name "*.flac" -type f -delete
+			find ${downloadDir}/. -type f -name "*.flac" -delete
 		fi
 	else
 		logit "Skipping KeepOnly Quality Cleanup"
@@ -125,6 +125,18 @@ Cleanup(){
 		find ${downloadDir}/ -empty -type d -delete
 	else
 		logit "Skipping Unwanted file removal"
+	fi
+}
+
+ExternalProcess(){
+	if [ "${ExternalProcess}" = True ];then
+		dlloc=${downloadDir}/*
+		for d in $dlloc; do
+			logit "Moving Downloads"
+			mv "$d" ${externalprocessdirectory}
+		done
+	else
+		logit "Skipping External Processing"
 	fi
 }
 
@@ -191,6 +203,7 @@ WantedModeBegin(){
 			continue
 		fi
 		Cleanup
+		ExternalProcess
 		if [ "${EnableLidarrProcess}" = True ] && [ -n "${LidArtistDLName}" ];then
 				logit "Sending to Lidarr for post Processing"
 				dlloc=${downloadDir}/*
@@ -236,6 +249,7 @@ ArtistModeBegin(){
 		fi
 	done
 	Cleanup
+	ExternalProcess
 	if [ "${EnableLidarrProcess}" = True ];then
 		logit "Sending to Lidarr for post Processing"
 		dlloc=${downloadDir}/*

--- a/lidarr-smloadr.sh
+++ b/lidarr-smloadr.sh
@@ -199,6 +199,17 @@ ArtistModeBegin(){
 		if [ -n "${DeezerArtistID}" ] || [ -n "${LidArtistName}" ] || [ -n "${DeezerArtistURL}" ]; then
 			DownloadURL "${DeezerArtistURL}"
 			logit "DeezerArtistURL: ${DeezerArtistURL}"
+			
+			if [ "${EnableLidarrProcess}" = True ];then
+				logit "Sending to Lidarr for post Processing"
+				dlloc=${downloadDir}/*
+				for d in $dlloc; do
+					LidarrProcessIt=$(curl -s "$lidarrUrl/api/v1/command" --header "X-Api-Key:"${lidarrApiKey} --data '{"name":"DownloadedAlbumsScan", "path":"'"$d"'"}' );
+				done
+			else
+			logit "Skipping Lidarr Processing"
+			fi
+			
 		else
 			logit "Cant get artistname or or DeezerArtistURL or artistid.. skipping" 
 			skiplog "${LidArtistName};${DeezerArtistID};${DeezerArtistURL};${LidAlbumName}"


### PR DESCRIPTION
Adds an option to move the files to a different location, that could be scanned using additional scripts such as Beets. This can enable a workflows such as:  Lidarr -> SMLoader -> Beets -> Lidarr. 

That way you can tweak the matching engine or do something entirely different with the data.